### PR TITLE
Strengthen CI dependency and API client checks

### DIFF
--- a/.github/actions/setup-node-project/action.yml
+++ b/.github/actions/setup-node-project/action.yml
@@ -1,5 +1,5 @@
 name: Setup Node Project
-description: Setup Node.js with npm cache and install dependencies for a project
+description: Setup Node.js with npm cache and install locked dependencies for a project
 inputs:
   node-version:
     description: Node.js version
@@ -23,4 +23,4 @@ runs:
     - name: Install dependencies
       shell: bash
       working-directory: ${{ inputs.working-directory }}
-      run: npm install
+      run: npm ci

--- a/.github/workflows/fe.yml
+++ b/.github/workflows/fe.yml
@@ -18,6 +18,11 @@ jobs:
           node-version: '20.x'
           working-directory: ./frontend
           cache-dependency-path: ./frontend/package-lock.json
+      - name: Generate API client
+        run: npm run generate:api
+      - name: Check generated API client
+        working-directory: .
+        run: git diff --exit-code -- frontend/src/services/api/generated
       - name: Lint
         run: npm run lint
       - name: Compile

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -3,16 +3,16 @@
 GitHub Actions は用途ごとに workflow を分割しています。すべて `push` をトリガーに実行されます。
 
 - `fe.yml`
-  `frontend` を対象に `npm install`、lint、TypeScript compile、test、build を実行します。
+  `frontend` を対象に `npm ci`、OpenAPI クライアント生成、生成物の差分検出、lint、TypeScript compile、test、build を実行します。
 - `be.yml`
-  `api/node` を対象に依存関係の導入、Prisma Client 生成、Vitest、build を実行します。
+  `api/node` を対象に `npm ci`、Prisma Client 生成、Vitest、build を実行します。
 - `e2e.yml`
   PostgreSQL をサービスとして起動し、`api/node` を build / migrate / seed / 起動したうえで、`api-spec` 配下の TypeScript 製 E2E から `swagger.yaml` の仕様検証を行います。
 
 共通処理は `.github/actions/` 配下の composite action に切り出しています。
 
 - `.github/actions/setup-node-project`
-  Node.js のセットアップ、npm キャッシュ、`npm install`
+  Node.js のセットアップ、npm キャッシュ、`npm ci`
 - `.github/actions/prepare-node-api`
   `api/node` 用のセットアップと Prisma Client 生成
 - `.github/actions/wait-for-http`


### PR DESCRIPTION
# CI の依存導入と API クライアント生成チェックを強化

## Summary
CI で lockfile に基づく依存導入を行い、frontend の OpenAPI 生成物が仕様に追従しているかを検出できるようにします。

**主な変更点:**
- 共通 Node setup action の依存導入を `npm install` から `npm ci` に変更
- Frontend Pipeline に `npm run generate:api` を追加
- 生成後に `frontend/src/services/api/generated` の差分が残っていないか `git diff --exit-code` で検出

## やったこと
- `.github/actions/setup-node-project/action.yml` を lockfile 固定インストールへ変更
- `.github/workflows/fe.yml` に API client 生成と生成物 drift check を追加
- `docs/ci.md` を現在の CI 内容に合わせて更新

## 動作確認
- [x] `cd api/node && npm ci`
- [x] `cd api/node && npm run prisma:generate`
- [x] `cd api/node && npm test`
- [x] `cd api/node && npm run build`
- [x] `cd frontend && npm ci`
- [x] `cd frontend && npm run generate:api`
- [x] `git diff --exit-code -- frontend/src/services/api/generated`
- [x] `cd frontend && npm run lint`
- [x] `cd frontend && npm run compile`
- [x] `cd frontend && npm test`
- [x] `cd frontend && npm run build`

## レビュー & 動作確認 チェックリスト
- [ ] **Frontend generated client drift** - OpenAPI 生成後に generated 配下の差分が CI で検出されること
- [ ] **Lockfile install** - すべての Node project setup が `npm ci` で lockfile に従うこと
- [ ] **CI docs** - `docs/ci.md` の説明が workflow と一致していること

**推奨テスト計画:**
1. PR の Frontend Pipeline が `Generate API client` と `Check generated API client` を実行することを確認する。
2. Backend Pipeline / API Spec E2E が `npm ci` でも通ることを確認する。
3. generated client に未反映差分がある場合、Frontend Pipeline が失敗することを必要に応じて別途確認する。

## その他気になることや相談ごと
ローカル `npm ci` では一部 dependency の engine warning と audit warning が出ていますが、コマンド自体は成功しています。今回の変更では依存更新は行っていません。
